### PR TITLE
Fix 404s for states with multi-word names

### DIFF
--- a/src/app/(drilldown)/states/StateExpenditures.tsx
+++ b/src/app/(drilldown)/states/StateExpenditures.tsx
@@ -74,7 +74,7 @@ export default async function StateExpenditures() {
           <>
             <tr key={state} className={styles.headerRow}>
               <td colSpan={2} className="text-cell">
-                <Link href={`/states/${stateName.toLocaleLowerCase()}`}>
+                <Link href={`/states/${stateName.toLowerCase().replace(" ", "-")}`}>
                   {stateName}
                 </Link>
               </td>

--- a/src/app/(drilldown)/states/[state]/page.tsx
+++ b/src/app/(drilldown)/states/[state]/page.tsx
@@ -11,12 +11,17 @@ import ByRace, { RaceCardContentsSkeleton } from "./ByRace";
 import TotalSpending from "./TotalSpending";
 import styles from "./page.module.css";
 
+function stateNameFromUrl(urlName: string) {
+  const stateName = decodeURIComponent(urlName).split("-").join(" ");
+  return titlecase(stateName);
+}
+
 export function generateMetadata({
   params,
 }: {
   params: { state: string };
 }): Metadata {
-  const state = titlecase(params.state.split("-").join(" "));
+  const state = stateNameFromUrl(params.state);
   return customMetadata({
     title: state,
     description: `Cryptocurrency-focused political action committee spending on 2024 elections in ${state}.`,
@@ -28,7 +33,7 @@ export default function CommitteePage({
 }: {
   params: { state: string };
 }) {
-  const titlecasedState = titlecase(params.state.split("-").join(" "));
+  const titlecasedState = stateNameFromUrl(params.state);
   if (!(titlecasedState in STATES_BY_FULL)) {
     notFound();
   }


### PR DESCRIPTION
Hi, I’m so glad to see this project live; thanks for building it!

I was browsing around it a bit this morning and realized the state pages for states with multi-word names (e.g. [West Virginia](https://www.followthecrypto.org/states/west%20virginia), [New York](https://www.followthecrypto.org/states/new%20york)) render 404 errors. This resolves the issue by decoding the URL param with the state name before handling it.

It might also be good to switch to using abbreviations or slugifying the names in links by replacing the spaces with dashes (it looks like this is what the code was expecting). I went for a minimal fix here that still keeps the existing URLs working.