### PR TITLE
Fix state expenditure pointing to wrong elections url path

### DIFF
--- a/src/app/(drilldown)/states/StateExpenditures.tsx
+++ b/src/app/(drilldown)/states/StateExpenditures.tsx
@@ -87,7 +87,7 @@ export default async function StateExpenditures() {
                 <tr key={raceKey}>
                   <td></td>
                   <td className="text-cell">
-                    <Link href={`/race/${raceKey}`}>
+                    <Link href={`/elections/${raceKey}`}>
                       {getRaceName(raceKey)}
                     </Link>
                   </td>


### PR DESCRIPTION
At [https://www.followthecrypto.org/states](url) the links to elections point to "/race" and not "/elections" so clicking one currently results in a 404.